### PR TITLE
Add pokemon overview on details page (closes #2)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -127,8 +127,7 @@ export default function Home() {
             {filteredPokemon && filteredPokemon.length > 0 ? (
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
                 {filteredPokemon.map((pokemon) => (
-                  <PokemonCard key={pokemon.id} pokemon={pokemon} />
-                ))}
+                  <PokemonCard key={pokemon.id} pokemon={pokemon} handleClick={handlePokemonClick} />                ))}
               </div>
             ) : (
               <NoPokemonFound />

--- a/app/pokemon/[id]/page.tsx
+++ b/app/pokemon/[id]/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, Zap } from 'lucide-react';
+import { formatPokemonId, formatPokemonName } from '@/lib/pokemon-utils';
+import { usePokemonDetails } from '@/hooks/use-pokemon-details';
+import { PokemonDetails } from '@/components/pokemon-details';
+
+export default function PokemonDetailPage() {
+  const { id } = useParams();
+  const router = useRouter();
+
+  const { pokemon, isLoading, error } = usePokemonDetails(+id);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+      <header
+        className="
+    sticky top-0 z-10 bg-white/80 backdrop-blur-md border-b border-gray-200 shadow-sm
+    flex items-center gap-4 px-4 sm:px-81 h-20 sm:h-14"
+      >
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.back()}
+          className="flex items-center gap-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Button>
+
+        <Zap className="h-6 w-6 sm:h-7 sm:w-7 text-yellow-500" />
+
+        <h1 className="bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent text-3xl font-bold capitalize whitespace-nowrap">
+          {pokemon ? formatPokemonName(pokemon.name) : "Loading..."}
+        </h1>
+
+        <p className="text-lg font-normal text-muted-foreground whitespace-nowrap">
+          {pokemon ? `${formatPokemonId(pokemon.id)}` : ""}
+        </p>
+      </header>
+
+      <main className="container mx-auto px-4 py-8">
+        {isLoading && (
+          <div className="text-center text-gray-600 mt-8">
+            Loading Pokémon...
+          </div>
+        )}
+
+        {error && (
+          <div className="text-center text-red-500 mt-8">
+            Failed to load Pokémon. Please try again.
+          </div>
+        )}
+
+        {!isLoading && !error && pokemon && (
+          <PokemonDetails pokemon={pokemon} />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/components/pokemon-card.tsx
+++ b/components/pokemon-card.tsx
@@ -9,9 +9,10 @@ import { useState } from 'react';
 
 interface PokemonCardProps {
   pokemon: Pokemon;
+  handleClick: (pokemon: Pokemon) => void;
 }
 
-export function PokemonCard({ pokemon }: PokemonCardProps) {
+export function PokemonCard({ handleClick, pokemon }: PokemonCardProps) {
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
 
@@ -26,7 +27,7 @@ export function PokemonCard({ pokemon }: PokemonCardProps) {
 
   return (
     <Card className="group transition-all duration-300 hover:scale-105 hover:shadow-2xl hover:shadow-blue-500/25 border-0 bg-white/90 backdrop-blur-sm overflow-hidden">
-      <CardContent className="p-6">
+      <CardContent className="p-6" onClick={() => handleClick(pokemon)}>
         <div className="text-center">
           {/* Pokemon ID */}
           <div className="text-sm font-medium text-muted-foreground mb-2">

--- a/components/pokemon-details.tsx
+++ b/components/pokemon-details.tsx
@@ -1,0 +1,21 @@
+import { Pokemon } from '@/types/pokemon';
+import { PokemonOverview } from './pokemon-overview';
+
+interface PokemonDetailsProps {
+  pokemon: Pokemon;
+}
+
+export function PokemonDetails({ pokemon }: PokemonDetailsProps) {
+  if (!pokemon) {
+    return (
+      <div className="text-center text-gray-600 mt-8">
+        Loading Pokémon details...
+      </div>
+    );
+  }
+  return (
+    <div className="max-w-[800px] mx-auto pt-4 pb-4  bg-white/80 backdrop-blur-md rounded-lg shadow-md">
+      <PokemonOverview pokemon={pokemon} />
+    </div>
+  );
+}

--- a/components/pokemon-overview.tsx
+++ b/components/pokemon-overview.tsx
@@ -1,0 +1,103 @@
+import {
+  formatPokemonName,
+  formatTypeName,
+  getPokemonImageUrl,
+  getTypeColor,
+} from '@/lib/pokemon-utils';
+import { Pokemon } from '@/types/pokemon';
+import Image from 'next/image';
+import { useState } from 'react';
+import { Skeleton } from './ui/skeleton';
+
+interface PokemonOverviewProps {
+  pokemon: Pokemon | undefined;
+}
+
+export function PokemonOverview({ pokemon }: PokemonOverviewProps) {
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  const pokemonHeight = pokemon?.height ? pokemon.height / 10 : 0;
+  const pokemonWeight = pokemon?.weight ? pokemon.weight / 10 : 0;
+
+  const handleImageLoad = () => {
+    setImageLoaded(true);
+  };
+
+  const handleImageError = () => {
+    setImageError(true);
+    setImageLoaded(true);
+  };
+
+  if (!pokemon) {
+    return (
+      <div className="text-center text-gray-600 mt-8">
+        Loading Pokémon details...
+      </div>
+    );
+  }
+
+  return (
+    <section className="from-white via-blue-50/30 to-purple-50/30 bg-gradient-to-br p-4 rounded-lg">
+      <div className="flex flex-col items-center mb-8">
+        <div className="relative w-full max-w-[300px] lg:w-40 lg:h-40 aspect-square mb-4">
+          {!imageLoaded && (
+            <Skeleton className="absolute inset-0 rounded-full" />
+          )}
+          <div className="absolute inset-0 bg-gradient-to-br from-blue-50 to-purple-50 rounded-full opacity-50 group-hover:opacity-80 transition-opacity duration-300" />
+          {!imageError ? (
+            <Image
+              src={getPokemonImageUrl(pokemon.id)}
+              alt={formatPokemonName(pokemon.name)}
+              fill
+              loading="lazy"
+              unoptimized
+              className={`object-contain transition-all duration-300 ${
+                imageLoaded ? "opacity-100" : "opacity-0"
+              } group-hover:scale-110`}
+              onLoad={handleImageLoad}
+              onError={handleImageError}
+            />
+          ) : (
+            <div className="flex items-center justify-center h-full text-6xl">
+              🎯
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col items-center gap-y-12 lg:gap-y-8 lg:items-center">
+          <div className="flex flex-col items-center gap-4 lg:flex-row lg:gap-8">
+            <div className="flex flex-col items-center lg:items-start">
+              <div className="text-sm text-muted-foreground">Height</div>
+              <div className="text-2xl font-bold text-gray-800">
+                {pokemonHeight} m
+              </div>
+            </div>
+            <div className="flex flex-col items-center lg:items-center">
+              <div className="text-sm text-muted-foreground">Weight</div>
+              <div className="text-2xl font-bold text-gray-800">
+                {pokemonWeight} kg
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap justify-center gap-2 lg:justify-start">
+            {pokemon.types?.map(({ type }) => (
+              <span
+                key={type.name}
+                className="text-base font-medium text-white px-3 py-1 rounded-full"
+                style={{
+                  backgroundColor: getTypeColor(type.name),
+                }}
+              >
+                {formatTypeName(type.name)}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* TODO: Add Abilities and Base Stats */}
+    </section>
+  );
+}

--- a/hooks/use-pokemon-details.tsx
+++ b/hooks/use-pokemon-details.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from './use-query';
+import { getPokemonDetails } from '@/lib/api';
+
+export function usePokemonDetails(id: number) {
+  const { data, isLoading, error } = useQuery(
+    `pokemon-${id}`,
+    `pokemon-${id}`,
+    async () => {
+      return getPokemonDetails(id);
+    }
+  );
+
+  return { pokemon: data, isLoading, error };
+}

--- a/lib/pokemon-utils.ts
+++ b/lib/pokemon-utils.ts
@@ -6,8 +6,16 @@ export function getPokemonImageUrl(id: number): string {
   return `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${id}.png`;
 }
 
+export function formatPokemonId(id: number): string {
+  return `#${id.toString().padStart(3, '0')}`;
+}
+
 export function formatPokemonName(name: string): string {
   return name.charAt(0).toUpperCase() + name.slice(1).replace('-', ' ');
+}
+
+export function formatTypeName(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
 export function getTypeColor(type: string): string {


### PR DESCRIPTION
This PR implements the Pokemon Overview section on the Pokemon Details page, as outlined in issue #2. It displays key information such as the Pokémon’s image, height and weight, providing users with a comprehensive view of each Pokemon in a structured layout.