### PR TITLE
Pokemon Base Stats on Details Page

### DIFF
--- a/components/pokemon-base-stats.tsx
+++ b/components/pokemon-base-stats.tsx
@@ -1,0 +1,36 @@
+import { formatStatsName } from "@/lib/pokemon-utils";
+import { Pokemon } from "@/types/pokemon";
+import { Progress } from "@radix-ui/react-progress";
+
+interface PokemonBaseStatsProps {
+  pokemon: Pokemon;
+}
+
+export function PokemonBaseStats({ pokemon }: PokemonBaseStatsProps) {
+  return (
+    <section>
+      <h3 className="font-medium text-gray-700 mt-4 mb-4">Base Stats</h3>
+      <div className="flex flex-col gap-4">
+        {pokemon.stats?.map((s) => (
+          <div key={s.stat.name} className="flex flex-col gap-1">
+            <div className="flex justify-between">
+              <span className="font-medium text-gray-700">
+                {formatStatsName(s.stat.name)}
+              </span>
+              <span className="font-bold text-gray-800">{s.base_stat}</span>
+            </div>
+            <Progress
+              value={(s.base_stat / 255) * 100}
+              className="relative h-3 w-full overflow-hidden rounded-full bg-gray-200"
+            >
+              <div
+                className="h-full bg-black"
+                style={{ width: `${(s.base_stat / 255) * 100}%` }}
+              />
+            </Progress>
+          </div>
+        ))} 
+      </div>
+    </section>
+  );
+}

--- a/components/pokemon-details.tsx
+++ b/components/pokemon-details.tsx
@@ -1,5 +1,6 @@
 import { Pokemon } from '@/types/pokemon';
 import { PokemonOverview } from './pokemon-overview';
+import { PokemonBaseStats } from './pokemon-base-stats';
 
 interface PokemonDetailsProps {
   pokemon: Pokemon;
@@ -14,8 +15,9 @@ export function PokemonDetails({ pokemon }: PokemonDetailsProps) {
     );
   }
   return (
-    <div className="max-w-[800px] mx-auto pt-4 pb-4  bg-white/80 backdrop-blur-md rounded-lg shadow-md">
+    <div className="max-w-[800px] mx-auto pt-4 pb-4  bg-white/80 backdrop-blur-md rounded-lg shadow-md p-4">
       <PokemonOverview pokemon={pokemon} />
+      <PokemonBaseStats pokemon={pokemon} />
     </div>
   );
 }

--- a/components/pokemon-overview.tsx
+++ b/components/pokemon-overview.tsx
@@ -37,7 +37,7 @@ export function PokemonOverview({ pokemon }: PokemonOverviewProps) {
   }
 
   return (
-    <section className="from-white via-blue-50/30 to-purple-50/30 bg-gradient-to-br p-4 rounded-lg">
+    <section className="from-white via-blue-50/30 to-purple-50/30 bg-gradient-to-br rounded-lg">
       <div className="flex flex-col items-center mb-8">
         <div className="relative w-full max-w-[300px] lg:w-40 lg:h-40 aspect-square mb-4">
           {!imageLoaded && (
@@ -107,8 +107,6 @@ export function PokemonOverview({ pokemon }: PokemonOverviewProps) {
             ))}
         </ul>
       </section>
-
-      {/* TODO: Add Base Stats */}
     </section>
   );
 }

--- a/lib/pokemon-utils.ts
+++ b/lib/pokemon-utils.ts
@@ -14,6 +14,13 @@ export function formatPokemonName(name: string): string {
   return name.charAt(0).toUpperCase() + name.slice(1).replace('-', ' ');
 }
 
+export function formatStatsName(name: string): string {
+  return name
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 export function formatTypeName(name: string): string {
   return name.charAt(0).toUpperCase() + name.slice(1);
 }


### PR DESCRIPTION
This PR implements the Pokemon Base Stats section on the Details Page, as outlined in issue #6. It displays each stat with its label, value, and a black progress bar, giving users a clear and structured overview of a Pokemon’s strengths.