### PR TITLE
Refactor: move abilities from overview to details(closes #8)

### DIFF
--- a/components/pokemon-abilities-wrapper.tsx
+++ b/components/pokemon-abilities-wrapper.tsx
@@ -1,0 +1,31 @@
+import { Pokemon } from '@/types/pokemon';
+import { PokemonAbility } from './pokemon-ability';
+
+interface PokemonAbilitiesWrapperProps {
+  pokemon: Pokemon | undefined;
+}
+
+export function PokemonAbilitiesWrapper({
+  pokemon,
+}: PokemonAbilitiesWrapperProps) {
+  if (!pokemon) {
+    return null;
+  }
+  if (!pokemon.abilities) {
+    return null;
+  }
+  return (
+    <section>
+      <h2 className="text-xl font-semibold text-gray-800 mb-4">Abilities</h2>
+      <ul className="flex flex-col gap-4">
+        {pokemon.abilities.map((a) => (
+          <PokemonAbility
+            key={a.ability.name}
+            abilityName={a.ability.name}
+            isHidden={a.is_hidden}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/components/pokemon-details.tsx
+++ b/components/pokemon-details.tsx
@@ -1,6 +1,7 @@
 import { Pokemon } from '@/types/pokemon';
 import { PokemonOverview } from './pokemon-overview';
 import { PokemonBaseStats } from './pokemon-base-stats';
+import { PokemonAbilitiesWrapper } from './pokemon-abilities-wrapper';
 
 interface PokemonDetailsProps {
   pokemon: Pokemon;
@@ -17,6 +18,7 @@ export function PokemonDetails({ pokemon }: PokemonDetailsProps) {
   return (
     <div className="max-w-[800px] mx-auto pt-4 pb-4  bg-white/80 backdrop-blur-md rounded-lg shadow-md p-4">
       <PokemonOverview pokemon={pokemon} />
+      <PokemonAbilitiesWrapper pokemon={pokemon} />
       <PokemonBaseStats pokemon={pokemon} />
     </div>
   );

--- a/components/pokemon-overview.tsx
+++ b/components/pokemon-overview.tsx
@@ -8,7 +8,6 @@ import { Pokemon } from '@/types/pokemon';
 import Image from 'next/image';
 import { useState } from 'react';
 import { Skeleton } from './ui/skeleton';
-import { PokemonAbility } from './pokemon-ability';
 
 interface PokemonOverviewProps {
   pokemon: Pokemon | undefined;
@@ -37,76 +36,58 @@ export function PokemonOverview({ pokemon }: PokemonOverviewProps) {
   }
 
   return (
-    <section className="from-white via-blue-50/30 to-purple-50/30 bg-gradient-to-br rounded-lg">
-      <div className="flex flex-col items-center mb-8">
-        <div className="relative w-full max-w-[300px] lg:w-40 lg:h-40 aspect-square mb-4">
-          {!imageLoaded && (
-            <Skeleton className="absolute inset-0 rounded-full" />
-          )}
-          <div className="absolute inset-0 bg-gradient-to-br from-blue-50 to-purple-50 rounded-full opacity-50 group-hover:opacity-80 transition-opacity duration-300" />
-          {!imageError ? (
-            <Image
-              src={getPokemonImageUrl(pokemon.id)}
-              alt={formatPokemonName(pokemon.name)}
-              fill
-              loading="lazy"
-              unoptimized
-              className={`object-contain transition-all duration-300 ${
-                imageLoaded ? "opacity-100" : "opacity-0"
-              } group-hover:scale-110`}
-              onLoad={handleImageLoad}
-              onError={handleImageError}
-            />
-          ) : (
-            <div className="flex items-center justify-center h-full text-6xl">
-              🎯
-            </div>
-          )}
-        </div>
-
-        <div className="flex flex-col items-center gap-y-8 lg:gap-y-8 lg:items-center">
-          <div className="flex flex-col items-center gap-4 lg:flex-row lg:gap-8">
-            <div className="flex flex-col items-center lg:items-start">
-              <div className="text-sm text-muted-foreground">Height</div>
-              <div className="text-2xl font-bold text-gray-800">
-                {pokemonHeight} m
-              </div>
-            </div>
-            <div className="flex flex-col items-center lg:items-center">
-              <div className="text-sm text-muted-foreground">Weight</div>
-              <div className="text-2xl font-bold text-gray-800">
-                {pokemonWeight} kg
-              </div>
-            </div>
+    <section className="flex flex-col items-center mb-8">
+      <div className="relative w-full max-w-[300px] lg:w-40 lg:h-40 aspect-square mb-4">
+        {!imageLoaded && <Skeleton className="absolute inset-0 rounded-full" />}
+        <div className="absolute inset-0 bg-gradient-to-br from-blue-50 to-purple-50 rounded-full opacity-50 group-hover:opacity-80 transition-opacity duration-300" />
+        {!imageError ? (
+          <Image
+            src={getPokemonImageUrl(pokemon.id)}
+            alt={formatPokemonName(pokemon.name)}
+            fill
+            loading="lazy"
+            unoptimized
+            className={`object-contain transition-all duration-300 ${
+              imageLoaded ? "opacity-100" : "opacity-0"
+            } group-hover:scale-110`}
+            onLoad={handleImageLoad}
+            onError={handleImageError}
+          />
+        ) : (
+          <div className="flex items-center justify-center h-full text-6xl">
+            🎯
           </div>
-
-          <div className="flex flex-wrap justify-center gap-2 lg:justify-start">
-            {pokemon.types?.map(({ type }) => (
-              <span
-                key={type.name}
-                className="text-base font-medium text-white px-3 py-1 rounded-full"
-                style={{ backgroundColor: getTypeColor(type.name) }}
-              >
-                {formatTypeName(type.name)}
-              </span>
-            ))}
-          </div>
-        </div>
+        )}
       </div>
 
-      <section>
-        <h2 className="text-xl font-semibold text-gray-800 mb-4">Abilities</h2>
-        <ul className="flex flex-col gap-4">
-          {pokemon.abilities &&
-            pokemon.abilities.map((a) => (
-              <PokemonAbility
-                key={a.ability.name}
-                abilityName={a.ability.name}
-                isHidden={a.is_hidden}
-              />
-            ))}
-        </ul>
-      </section>
+      <div className="flex flex-col items-center gap-y-8 lg:gap-y-8 lg:items-center">
+        <div className="flex flex-col items-center gap-4 lg:flex-row lg:gap-8">
+          <div className="flex flex-col items-center lg:items-start">
+            <div className="text-sm text-muted-foreground">Height</div>
+            <div className="text-2xl font-bold text-gray-800">
+              {pokemonHeight} m
+            </div>
+          </div>
+          <div className="flex flex-col items-center lg:items-center">
+            <div className="text-sm text-muted-foreground">Weight</div>
+            <div className="text-2xl font-bold text-gray-800">
+              {pokemonWeight} kg
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap justify-center gap-2 lg:justify-start">
+          {pokemon.types?.map(({ type }) => (
+            <span
+              key={type.name}
+              className="text-base font-medium text-white px-3 py-1 rounded-full"
+              style={{ backgroundColor: getTypeColor(type.name) }}
+            >
+              {formatTypeName(type.name)}
+            </span>
+          ))}
+        </div>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
This PR refactors the Pokemon Details page by moving the Abilities section out of the PokemonOverview component. The Abilities are now rendered directly on the Details, keeping the Overview focused on high-level Pokemon information while maintaining the existing functionality and styling, explain in #8