### PR TITLE
Implement the tabs for details page

### DIFF
--- a/components/pokemon-details-tab.tsx
+++ b/components/pokemon-details-tab.tsx
@@ -1,0 +1,16 @@
+import { Pokemon } from '@/types/pokemon';
+import { PokemonAbilitiesWrapper } from './pokemon-abilities-wrapper';
+import { PokemonBaseStats } from './pokemon-base-stats';
+
+interface PokemonDetailsTabProps {
+  pokemon: Pokemon;
+}
+
+export function PokemonDetailsTab({ pokemon }: PokemonDetailsTabProps) {
+  return (
+    <div className="space-y-6">
+      <PokemonAbilitiesWrapper pokemon={pokemon} />
+      <PokemonBaseStats pokemon={pokemon} />
+    </div>
+  );
+}

--- a/components/pokemon-details.tsx
+++ b/components/pokemon-details.tsx
@@ -1,7 +1,8 @@
 import { Pokemon } from '@/types/pokemon';
+import { InfoIcon, TrendingUp } from 'lucide-react';
+import { PokemonDetailsTab } from './pokemon-details-tab';
 import { PokemonOverview } from './pokemon-overview';
-import { PokemonBaseStats } from './pokemon-base-stats';
-import { PokemonAbilitiesWrapper } from './pokemon-abilities-wrapper';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
 
 interface PokemonDetailsProps {
   pokemon: Pokemon;
@@ -18,8 +19,26 @@ export function PokemonDetails({ pokemon }: PokemonDetailsProps) {
   return (
     <div className="max-w-[800px] mx-auto pt-4 pb-4  bg-white/80 backdrop-blur-md rounded-lg shadow-md p-4">
       <PokemonOverview pokemon={pokemon} />
-      <PokemonAbilitiesWrapper pokemon={pokemon} />
-      <PokemonBaseStats pokemon={pokemon} />
+      <Tabs defaultValue="details" className="mt-4">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="details">
+            <InfoIcon className="w-4 h-4 mr-2" />
+            Details
+            </TabsTrigger>
+          <TabsTrigger value="stats">
+            <TrendingUp className="w-4 h-4 mr-2" />
+            Stats Chart
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="details" className="mt-4">
+          <PokemonDetailsTab pokemon={pokemon} />
+        </TabsContent>
+        <TabsContent value="stats" className="mt-4">
+          <div className="text-center text-gray-600 mt-8">
+            Stats Charts coming soon...
+          </div>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }


### PR DESCRIPTION
This PR deals with the basic tab implementation on the details page. It sets up the tabbed layout as a foundation for future enhancements.

### Changes Included

- Added tabbed navigation with two tabs: Details and Stats Chart

- Added placeholder content to stats chart tab to verify switching works correctly

- Established structure for extending functionality in future PRs