### PR TITLE
Dynamic Stats Data and Abilities

### DIFF
--- a/components/pokemon-stats-chart.tsx
+++ b/components/pokemon-stats-chart.tsx
@@ -1,24 +1,39 @@
 'use client';
 
+import { formatStatsName } from '@/lib/pokemon-utils';
 import { Pokemon } from '@/types/pokemon';
+import { BarChart3Icon } from 'lucide-react';
 import { Bar, BarChart, CartesianGrid, Legend, XAxis, YAxis } from 'recharts';
 import { Card } from './ui/card';
-import { BarChart3Icon } from 'lucide-react';
 
 interface PokemonStatsChartProps {
   pokemon: Pokemon;
 }
 
 export function PokemonStatsChart({ pokemon }: PokemonStatsChartProps) {
-  // Dummy data for initial implementation
-  const dummyChartData = [
-    { name: "HP", baseStat: 45, modifiedStat: 50 },
-    { name: "Attack", baseStat: 49, modifiedStat: 54 },
-    { name: "Defense", baseStat: 49, modifiedStat: 54 },
-    { name: "Sp. Attack", baseStat: 65, modifiedStat: 72 },
-    { name: "Sp. Defense", baseStat: 65, modifiedStat: 72 },
-    { name: "Speed", baseStat: 45, modifiedStat: 50 },
-  ];
+  // Transform real Pokemon stats data for the chart
+  const chartData =
+    pokemon.stats?.map((stat) => ({
+      name: formatStatsName(stat.stat.name),
+      baseStat: stat.base_stat,
+      modifiedStat: stat.base_stat,
+    })) || [];
+
+  if (!pokemon.stats || chartData.length === 0) {
+    return (
+      <Card className="bg-gradient-to-br from-white via-blue-50/30 to-purple-50/30 p-6">
+        <div className="flex items-center gap-3 mb-4">
+          <BarChart3Icon className="w-6 h-6 text-blue-600" />
+          <h2 className="xl:text-2xl text-xl font-bold text-gray-800">
+            Base Stats vs Ability Effects
+          </h2>
+        </div>
+        <div className="text-center text-gray-600 mt-8">
+          No stats data available for this Pokémon.
+        </div>
+      </Card>
+    );
+  }
 
   return (
     <Card className="bg-gradient-to-br from-white via-blue-50/30 to-purple-50/30 p-6">
@@ -30,7 +45,7 @@ export function PokemonStatsChart({ pokemon }: PokemonStatsChartProps) {
       </div>
 
       <div className="w-full h-80">
-        <BarChart width={700} height={320} data={dummyChartData}>
+        <BarChart width={700} height={320} data={chartData}>
           <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
           <XAxis dataKey="name" />
           <YAxis

--- a/components/pokemon-stats-chart.tsx
+++ b/components/pokemon-stats-chart.tsx
@@ -1,23 +1,103 @@
-'use client';
+"use client";
 
+import { useAbilityDetails } from '@/hooks/use-ability-details';
+import { calculateAbilityEffect } from '@/lib/abilityEffects';
 import { formatStatsName } from '@/lib/pokemon-utils';
 import { Pokemon } from '@/types/pokemon';
-import { BarChart3Icon } from 'lucide-react';
+import { BarChart3Icon, Zap } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
 import { Bar, BarChart, CartesianGrid, Legend, XAxis, YAxis } from 'recharts';
-import { Card } from './ui/card';
+import { StatCard } from './stat-card';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { Card, CardContent } from './ui/card';
 
 interface PokemonStatsChartProps {
   pokemon: Pokemon;
 }
 
+interface SelectedAbility {
+  name: string;
+  isHidden: boolean;
+}
+
 export function PokemonStatsChart({ pokemon }: PokemonStatsChartProps) {
-  // Transform real Pokemon stats data for the chart
-  const chartData =
-    pokemon.stats?.map((stat) => ({
-      name: formatStatsName(stat.stat.name),
-      baseStat: stat.base_stat,
-      modifiedStat: stat.base_stat,
-    })) || [];
+  const [selectedAbility, setSelectedAbility] =
+    useState<SelectedAbility | null>(() => {
+      const firstAbility = pokemon.abilities?.[0];
+      return firstAbility
+        ? {
+            name: firstAbility.ability.name,
+            isHidden: firstAbility.is_hidden,
+          }
+        : null;
+    });
+
+  const getModifiedStat = useCallback(
+    (baseStat: number, statName: string) => {
+      if (!selectedAbility) return baseStat;
+
+      const { modified } = calculateAbilityEffect(
+        selectedAbility.name,
+        statName,
+        baseStat
+      );
+      return modified;
+    },
+    [selectedAbility]
+  );
+
+  const chartData = useMemo(
+    () =>
+      pokemon.stats?.map((stat) => ({
+        name: formatStatsName(stat.stat.name),
+        baseStat: stat.base_stat,
+        modifiedStat: getModifiedStat(stat.base_stat, stat.stat.name),
+      })) || [],
+    [pokemon.stats, getModifiedStat]
+  );
+
+  const baseTotal = useMemo(
+    () => chartData.reduce((sum, stat) => sum + stat.baseStat, 0),
+    [chartData]
+  );
+
+  const modifiedTotal = useMemo(
+    () => chartData.reduce((sum, stat) => sum + stat.modifiedStat, 0),
+    [chartData]
+  );
+
+  const netChange = useMemo(
+    () => modifiedTotal - baseTotal,
+    [modifiedTotal, baseTotal]
+  );
+
+  const handleAbilitySelect = useCallback(
+    (abilityName: string) => {
+      const abilityData = pokemon.abilities?.find(
+        (a) => a.ability.name === abilityName
+      );
+      if (abilityData) {
+        setSelectedAbility({
+          name: abilityData.ability.name,
+          isHidden: abilityData.is_hidden,
+        });
+      }
+    },
+    [pokemon.abilities]
+  );
+
+  const { ability } = useAbilityDetails(selectedAbility?.name || null);
+
+  const selectedAbilityDescription = useMemo(() => {
+    if (!ability?.effect_entries) return null;
+
+    const englishEntry = ability.effect_entries.find(
+      (entry) => entry.language.name === "en"
+    );
+
+    return englishEntry?.effect || null;
+  }, [ability]);
 
   if (!pokemon.stats || chartData.length === 0) {
     return (
@@ -44,6 +124,53 @@ export function PokemonStatsChart({ pokemon }: PokemonStatsChartProps) {
         </h2>
       </div>
 
+      <div className="mb-6">
+        <div className="flex items-center gap-2 mb-3">
+          <Zap className="w-4 h-4 text-gray-700" />
+          <h3 className="text-sm font-medium text-gray-700">Select Ability:</h3>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {pokemon.abilities?.map((ability) => (
+            <Button
+              key={ability.ability.name}
+              variant={
+                selectedAbility?.name === ability.ability.name
+                  ? "default"
+                  : "outline"
+              }
+              size="sm"
+              onClick={() => handleAbilitySelect(ability.ability.name)}
+            >
+              {ability.ability.name.charAt(0).toUpperCase() +
+                ability.ability.name.slice(1)}
+              {ability.is_hidden && (
+                <span className="ml-1 text-xs opacity-70">(Hidden)</span>
+              )}
+            </Button>
+          ))}
+        </div>
+
+        {selectedAbility && selectedAbilityDescription && (
+          <Card className="mt-3 bg-blue-50">
+            <CardContent className="p-3">
+              <div className="flex flex-col items-start gap-2">
+                <div className="font-medium text-black capitalize flex items-center gap-2">
+                  {selectedAbility.name.replace("-", " ")}:
+                  {selectedAbility.isHidden && (
+                    <Badge variant="outline" className="text-xs">
+                      Hidden
+                    </Badge>
+                  )}
+                </div>
+                <div className="text-sm text-gray-600 leading-relaxed">
+                  {selectedAbilityDescription}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
       <div className="w-full h-80">
         <BarChart width={700} height={320} data={chartData}>
           <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
@@ -59,6 +186,25 @@ export function PokemonStatsChart({ pokemon }: PokemonStatsChartProps) {
           <Bar dataKey="baseStat" fill="#3b82f6" name="Base Stat" />
           <Bar dataKey="modifiedStat" fill="#8b5cf6" name="Ability Modified" />
         </BarChart>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mt-12">
+        <StatCard title="Base Total" value={baseTotal} variant="base" />
+        <StatCard
+          title="Modified Total"
+          value={modifiedTotal}
+          variant="modified"
+        />
+        <StatCard title="Net Change" value={netChange} variant="change" />
+      </div>
+
+      <div className="mt-6 p-4">
+        <p className="text-sm text-gray-600 leading-relaxed">
+          <strong>Note:</strong> Ability effects shown are theoretical maximums
+          and may depend on battle conditions, status effects, weather, or other
+          factors not represented in this chart. Hover over bars to see detailed
+          stat information and ability effects.
+        </p>
       </div>
     </Card>
   );

--- a/components/stat-card.tsx
+++ b/components/stat-card.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+
+interface StatCardProps {
+  title: string;
+  value: number;
+  variant: "base" | "modified" | "change";
+}
+
+const getVariantStyles = (variant: StatCardProps["variant"]) => {
+  switch (variant) {
+    case "base":
+      return "bg-blue-50 text-blue-800";
+    case "modified":
+      return "bg-purple-50 text-purple-800";
+    case "change":
+      return "bg-gray-50 text-gray-800";
+    default:
+      return "bg-gray-50 text-gray-800";
+  }
+};
+
+const getValueStyles = (value: number, variant: StatCardProps["variant"]) => {
+  if (variant === "change") {
+    if (value > 0) return "text-green-600";
+    if (value < 0) return "text-red-600";
+  }
+  return "";
+};
+
+export function StatCard({ title, value, variant }: StatCardProps) {
+  const formatValue = () => {
+    if (variant === "change" && value > 0) {
+      return `+${value}`;
+    }
+    return value.toString();
+  };
+
+  return (
+    <Card className={getVariantStyles(variant)}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-center">
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div
+          className={`text-xl font-bold text-center ${getValueStyles(
+            value,
+            variant
+          )}`}
+        >
+          {formatValue()}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
This PR deals with updating the **Stats Chart** component to use **real Pokémon data** and dynamically calculate **ability-modified stats**. It replaces the dummy values from the previous PR and prepares the chart for full interactivity with abilities.

### Changes Included

- Replaced dummy chart data with real Pokémon base stats
- Implemented dynamic calculation of modified stats based on selected abilities
- Display ability descriptions below the chart
